### PR TITLE
put both summary and local variables on first line

### DIFF
--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -1,6 +1,4 @@
-;; -*- mode: emacs-lisp -*-
-
-;;; lusty-explorer.el --- Dynamic filesystem explorer and buffer switcher
+;;; lusty-explorer.el --- Dynamic filesystem explorer and buffer switcher -*- mode: emacs-lisp -*-
 ;;
 ;; Copyright (C) 2008 Stephen Bach <http://items.sjbach.com/about>
 ;;


### PR DESCRIPTION
Unfortunately both -*- and the summary line have to be on the first line. I use some code that also looks for the summary in the second line too (but not third) but lm-summary from built-in lisp-mnt.el only finds it if it's on the first line.
