### PR TITLE
Replaced deprecated macro `flet` with `noflet`

### DIFF
--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -85,9 +85,10 @@
 
 ;; Used only for its faces (for color-theme).
 (require 'dired)
-(defalias 'lusty-flet 'flet)
+;; Backward compatibility: use noflet if present, fallback to (deprecated since 24.3) flet otherwise
+(defalias 'lusty--flet 'flet)
 (when (require 'noflet nil 'noerror)
-  (defalias 'lusty-flet 'noflet))
+  (defalias 'lusty--flet 'noflet))
 
 
 (declaim (optimize (speed 3) (safety 0)))
@@ -614,7 +615,7 @@ does not begin with '.'."
 ;; already split frame is not a living window.
 (defun lusty-lowest-window ()
   "Return the lowest window on the frame."
-  (lusty-flet ((iterate-non-dedicated-window (start-win direction)
+  (lusty--flet ((iterate-non-dedicated-window (start-win direction)
            ;; Skip dedicated windows when iterating.
            (let ((iterating-p t)
                  (next start-win))
@@ -716,7 +717,7 @@ does not begin with '.'."
 (defun lusty-buffer-list ()
   "Return a list of buffers ordered with those currently visible at the end."
   (let ((visible-buffers '()))
-    (lusty-flet ((add-buffer-maybe (window)
+    (lusty--flet ((add-buffer-maybe (window)
              (let ((b (window-buffer window)))
                (unless (memq b visible-buffers)
                  (push b visible-buffers)))))

--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -85,7 +85,10 @@
 
 ;; Used only for its faces (for color-theme).
 (require 'dired)
-(require 'noflet)
+(defalias 'lusty-flet 'flet)
+(when (require 'noflet nil 'noerror)
+  (defalias 'lusty-flet 'noflet))
+
 
 (declaim (optimize (speed 3) (safety 0)))
 
@@ -611,7 +614,7 @@ does not begin with '.'."
 ;; already split frame is not a living window.
 (defun lusty-lowest-window ()
   "Return the lowest window on the frame."
-  (noflet ((iterate-non-dedicated-window (start-win direction)
+  (lusty-flet ((iterate-non-dedicated-window (start-win direction)
            ;; Skip dedicated windows when iterating.
            (let ((iterating-p t)
                  (next start-win))
@@ -713,7 +716,7 @@ does not begin with '.'."
 (defun lusty-buffer-list ()
   "Return a list of buffers ordered with those currently visible at the end."
   (let ((visible-buffers '()))
-    (noflet ((add-buffer-maybe (window)
+    (lusty-flet ((add-buffer-maybe (window)
              (let ((b (window-buffer window)))
                (unless (memq b visible-buffers)
                  (push b visible-buffers)))))

--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -85,6 +85,7 @@
 
 ;; Used only for its faces (for color-theme).
 (require 'dired)
+(require 'noflet)
 
 (declaim (optimize (speed 3) (safety 0)))
 
@@ -610,7 +611,7 @@ does not begin with '.'."
 ;; already split frame is not a living window.
 (defun lusty-lowest-window ()
   "Return the lowest window on the frame."
-  (flet ((iterate-non-dedicated-window (start-win direction)
+  (noflet ((iterate-non-dedicated-window (start-win direction)
            ;; Skip dedicated windows when iterating.
            (let ((iterating-p t)
                  (next start-win))
@@ -712,7 +713,7 @@ does not begin with '.'."
 (defun lusty-buffer-list ()
   "Return a list of buffers ordered with those currently visible at the end."
   (let ((visible-buffers '()))
-    (flet ((add-buffer-maybe (window)
+    (noflet ((add-buffer-maybe (window)
              (let ((b (window-buffer window)))
                (unless (memq b visible-buffers)
                  (push b visible-buffers)))))


### PR DESCRIPTION
Since emacs 24.3, `flet` is a deprecated macro, and `cl-flet` does not allow to redefine locally already defined functions.

I'm proposing to add a dependency to `noflet` to remove the warning message. 