### PR TITLE
Changes to better support Emacs 26

### DIFF
--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -85,11 +85,6 @@
 
 ;; Used only for its faces (for color-theme).
 (require 'dired)
-;; Backward compatibility: use noflet if present, fallback to (deprecated since 24.3) flet otherwise
-(defalias 'lusty--flet 'flet)
-(when (require 'noflet nil 'noerror)
-  (defalias 'lusty--flet 'noflet))
-
 
 (declaim (optimize (speed 3) (safety 0)))
 
@@ -626,7 +621,7 @@ does not begin with '.'."
 ;; already split frame is not a living window.
 (defun lusty-lowest-window ()
   "Return the lowest window on the frame."
-  (lusty--flet ((iterate-non-dedicated-window (start-win direction)
+  (cl-flet ((iterate-non-dedicated-window (start-win direction)
            ;; Skip dedicated windows when iterating.
            (let ((iterating-p t)
                  (next start-win))
@@ -728,7 +723,7 @@ does not begin with '.'."
 (defun lusty-buffer-list ()
   "Return a list of buffers ordered with those currently visible at the end."
   (let ((visible-buffers '()))
-    (lusty--flet ((add-buffer-maybe (window)
+    (cl-flet ((add-buffer-maybe (window)
              (let ((b (window-buffer window)))
                (unless (memq b visible-buffers)
                  (push b visible-buffers)))))

--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -204,7 +204,7 @@ buffer names in the matches window; 0.10 = %10."
            (>= y (length (aref lusty--matches-matrix 0)))
            (null (aref (aref lusty--matches-matrix x) y)))))
 
-(defsubst lusty--compute-column-width (start-index end-index lengths-v lengths-h)
+(defun lusty--compute-column-width (start-index end-index lengths-v lengths-h)
   (if (= start-index end-index)
       ;; Single-element remainder
       (aref lengths-v start-index)
@@ -226,7 +226,7 @@ buffer names in the matches window; 0.10 = %10."
                      (max first-half second-half)
                      lengths-h))))))
 
-(defsubst lusty--propertize-path (path)
+(defun lusty--propertize-path (path)
   "Propertize the given PATH like so: <dir></> or <file>.
 Uses the faces `lusty-directory-face', `lusty-slash-face', and
 `lusty-file-face'."
@@ -1052,7 +1052,7 @@ does not begin with '.'."
 (defconst LM--score-trailing-but-started 0.90)
 (defconst LM--score-buffer 0.85)
 
-(defsubst* LM-score (str abbrev)
+(defun* LM-score (str abbrev)
   (let ((str-len (length str))
         (abbrev-len (length abbrev)))
     (cond ;((string= abbrev "")  ; Disabled; can't happen in practice


### PR DESCRIPTION
I'm a huge fan and constant user of lusty-explorer for my file browsing, but after a recent update of the code, I found I was getting errors in Emacs 26:

 - Using `lusty-file-explorer` after a vertical split resulted in an "invalid function" error arising from the use of `lusty--flet`.  This was fixed by just using the now-recommended `cl-flet`.

 - After making the above change, attempting to re-byte-compile the file resulted in errors during byte-compilation about some resources being exhausted. Turning some of the uses of `defsubst` back into `defun` solved that problem.