### PR TITLE
Fix to prevent non-standard completing-read to interject

### DIFF
--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -251,7 +251,8 @@ Uses the faces `lusty-directory-face', `lusty-slash-face', and
 (defun lusty-file-explorer ()
   "Launch the file/directory mode of LustyExplorer."
   (interactive)
-  (let ((lusty--active-mode :file-explorer))
+  (let ((completing-read-function #'completing-read-default)
+        (lusty--active-mode :file-explorer))
     (lusty--define-mode-map)
     (let* ((lusty--ignored-extensions-regex
             (concat "\\(?:" (regexp-opt completion-ignored-extensions) "\\)$"))
@@ -272,7 +273,8 @@ Uses the faces `lusty-directory-face', `lusty-slash-face', and
 (defun lusty-buffer-explorer ()
   "Launch the buffer mode of LustyExplorer."
   (interactive)
-  (let ((lusty--active-mode :buffer-explorer))
+  (let ((completing-read-function #'completing-read-default)
+        (lusty--active-mode :buffer-explorer))
     (lusty--define-mode-map)
     (let* ((minibuffer-local-completion-map lusty-mode-map)
            (buffer (lusty--run 'read-buffer)))


### PR DESCRIPTION
Hello,

Here is a small fix to prevent non-standard `completing-read-function` to be triggered when running lusty.

The trick is to let-bind it to `#'completing-read-default`.

This is needed when [ivy-mode](https://github.com/abo-abo/swiper) is active.
I assume [Ido](https://www.gnu.org/software/emacs/manual/html_mono/ido.html) could also be concerned (untested).

Please note that this trick is not sufficient for [helm-mode](https://github.com/emacs-helm/helm).