### PR TITLE
Handle paste absolute path when at root of remote server

### DIFF
--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -6,6 +6,7 @@
 ;; Keywords: convenience, files, matching, tools
 ;; URL: https://github.com/sjbach/lusty-emacs
 ;; Compatibility: GNU Emacs 24.3+
+;; Package-Requires: ((s "1.11.0"))
 ;;
 ;; Permission is hereby granted to use and distribute this code, with or
 ;; without modifications, provided that this copyright notice is copied with

--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -1109,7 +1109,7 @@ does not begin with '.'."
     (set-keymap-parent map minibuffer-local-map)
     (define-key map (kbd "RET") #'lusty-open-this)
     (define-key map "\t" #'lusty-select-match)
-    (define-key map "\C-y" #'lusty-yank)
+    (define-key map [remap yank] #'lusty-yank)
     (define-key map [remap delete-backward-char] #'lusty-delete-backward)
 
     (define-key map "\C-n" #'lusty-highlight-next)

--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -444,8 +444,7 @@ and recency information."
 
 ;;;###autoload
 (defun lusty-yank (arg)
-  "Special yank that handles nicely case when current path \"/\" and pasted path starts w/ a leading \"/\" as well.
-Inspired by `lispy-yank'"
+  "Special yank that trims text and handles nicely edge-case when `default-directory' is at the root (\"/\") of a remote tramp connection and pasted path is absolute (starts with a leading \"/\")."
   (interactive "P")
   (setq this-command 'yank)
   (unless arg

--- a/lusty-explorer.el
+++ b/lusty-explorer.el
@@ -94,6 +94,8 @@
 ;; Used only for its faces (for color-theme).
 (require 'dired)
 
+(require 's)
+
 (cl-declaim (optimize (speed 3) (safety 0)))
 
 (defgroup lusty-explorer nil
@@ -447,8 +449,7 @@ Inspired by `lispy-yank'"
   (setq this-command 'yank)
   (unless arg
     (setq arg 0))
-  (let ((text (current-kill arg)))
-    (setq text (s-trim text))
+  (let ((text (s-trim (current-kill arg))))
     (cond
      ((and (region-active-p)
            (bound-and-true-p delete-selection-mode))


### PR DESCRIPTION
This PR allows to handle nicelly the following edge-case:
 - `default-directory` is the root of a remote server accessed via TRAMP (e.g. `/ssh:user@host:/`)
 - the clipboard contains a (valid) absolute path (hence starting with a `/`, e.g. `/usr/local/bin`)
 - we launch `lusty-file-explorer` and paste the content of the clipboard

On a non-patched lusty, we would end up with an invalid path in the minibuffer (e.g. `/ssh:user@host://usr/local/bin`) and would end up back on a local path (e.g. `/usr/local/bin`).

With patched version, we stay on the remote server (e.g. `/ssh:user@host:/usr/local/bin`).

In addition, for convenience, `lusty-yank` does a systematic trim of the pasted path.